### PR TITLE
Cray compiler fix

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -116,7 +116,7 @@ physics/module_gfdl_cloud_microphys.*          @RuiyuSun                        
 physics/module_MP_FER_HIRES.*                  @ericaligo-NOAA                      @grantfirl @Qingfu-Liu @dustinswales
 physics/module_mp_nssl_2mom.F90                                                     @grantfirl @Qingfu-Liu @dustinswales
 physics/module_mp_radar.*                      @gthompsnWRF @RuiyuSun               @grantfirl @Qingfu-Liu @dustinswales
-physics/module_mp_thompson*                    @gthompsnWRF @RuiyuSun               @grantfirl @Qingfu-Liu @dustinswales
+physics/module_mp_thompson*                    @gthompsnWRF @RuiyuSun @AndersJensen-NOAA @grantfirl @Qingfu-Liu @dustinswales
 physics/module_nst*                            @XuLi-NOAA                           @grantfirl @Qingfu-Liu @dustinswales
 physics/module_sf_exchcoef.f90                                                      @grantfirl @Qingfu-Liu @dustinswales
 physics/module_SF_JSFC.F90                     @Qingfu-Liu                          @grantfirl @Qingfu-Liu @dustinswales
@@ -126,7 +126,7 @@ physics/module_soil_pre.*                      @tanyasmirnova                   
 physics/moninshoc.*                            @SMoorthi-emc                        @grantfirl @Qingfu-Liu @dustinswales
 physics/mp_fer_hires.*                         @ericaligo-NOAA                      @grantfirl @Qingfu-Liu @dustinswales
 physics/mp_nssl.*                                                                   @grantfirl @Qingfu-Liu @dustinswales
-physics/mp_thompson*                           @gthompsnWRF @RuiyuSun               @grantfirl @Qingfu-Liu @dustinswales
+physics/mp_thompson*                           @gthompsnWRF @RuiyuSun @AndersJensen-NOAA @grantfirl @Qingfu-Liu @dustinswales
 physics/multi_gases.F90                        @RuiyuSun                            @grantfirl @Qingfu-Liu @dustinswales
 physics/myjpbl_wrapper.*                       @Qingfu-Liu                          @grantfirl @Qingfu-Liu @dustinswales
 physics/myjsfc_wrapper.*                       @Qingfu-Liu                          @grantfirl @Qingfu-Liu @dustinswales

--- a/physics/module_bl_mynn.F90
+++ b/physics/module_bl_mynn.F90
@@ -7521,7 +7521,7 @@ SUBROUTINE SCALE_AWARE(dx,PBL1,Psig_bl,Psig_shcu)
 
          dummy_0=(1.-am_unst*zet)          ! parentesis arg
          dummy_1=dummy_0**0.333333         ! y
-         dummy_11=-0.33333*am_unst*dummy_0**-0.6666667 ! dy/dzet
+         dummy_11=-0.33333*am_unst*dummy_0**(-0.6666667) ! dy/dzet
          dummy_2 = 0.33333*(dummy_1**2.+dummy_1+1.)    ! f
          dummy_22 = 0.3333*dummy_11*(2.*dummy_1+1.)    ! df/dzet
          dummy_3 = 0.57735*(2.*dummy_1+1.) ! g
@@ -7573,7 +7573,7 @@ SUBROUTINE SCALE_AWARE(dx,PBL1,Psig_bl,Psig_shcu)
 
          dummy_0=(1.-ah_unst*zet)          ! parentesis arg
          dummy_1=dummy_0**0.333333         ! y
-         dummy_11=-0.33333*ah_unst*dummy_0**-0.6666667 ! dy/dzet
+         dummy_11=-0.33333*ah_unst*dummy_0**(-0.6666667) ! dy/dzet
          dummy_2 = 0.33333*(dummy_1**2.+dummy_1+1.)    ! f
          dummy_22 = 0.3333*dummy_11*(2.*dummy_1+1.)    ! df/dzet
          dummy_3 = 0.57735*(2.*dummy_1+1.) ! g


### PR DESCRIPTION
- fix Cray compiler error having to do with binary/unary operator precedence standards
- add @AndersJensen-NOAA to CODEOWNERS for Thompson MP scheme